### PR TITLE
Add Phase 3 and Phase 4 Beta changelog

### DIFF
--- a/patches-2000-1.txt
+++ b/patches-2000-1.txt
@@ -838,7 +838,28 @@ understanding in this matter.
 
 .....................................................................
 
+------------------------------
+April 28, 2000
+------------------------------
 
+*Spells*
+- "Scale of Wolf" is now group-only. You must be grouped with the target in order to cast this spell upon them. This change was made due to the fact that Scale of Wolf  overwrites Spirit of Wolf , which may be more desirable in some situations.
+- The "Cannibalize II" spell has been enhanced.
+- Corrected a bug with "Song of the Sirens" that caused an unintended level-cap to affect the spell. Bards should now be able to charm everything that they once could with this spell.
+
+*Binding in Timorous Deep*
+Due to a feature within the zone, players can no longer bind within Timorous Deep. This functionality was intended in the zone prior to launch, as binding presents a possible balance issue. Players who are already bound in this zone will retain their binding location until they bind someplace else.
+
+*Iksar Quests*
+A few items associated with the Iksar newbie warrior quests have been repaired. The EverQuest team would like to extend thanks to those who reported the problems.
+
+*Iksar Factions*
+As announced in the patch server message yesterday, this morning we corrected a bug in Iksar faction that allowed them to travel outside Kunark without fear of being attacked by most things. In the event that any young Iksar find themselves in a bind/death loop, please /quit, log in another character, and /petition for assistance.
+
+*Server Splits*
+The recently announced server splits will be completed roughly two hours after the other servers come up from this patch. Movelog registered accounts from Veeshan and Bristlebane will be moved to Saryrn, and Xegony and Bertox to The Seventh Hammer. As requests to move were very strong, we were not able to move everyone who requested. We appreciate everyone's understanding.
+
+.....................................................................
 
 ------------------------------
 May 16, 2000  10:00 am

--- a/patches-phase3beta-eqnews.txt
+++ b/patches-phase3beta-eqnews.txt
@@ -1,0 +1,96 @@
+8/5/98 7:34pm
+-------------
+Additional information is now provided when you consider (double-click on) an NPC that will
+undoubtedly prove useful in the game.
+
+8/6/98 8:17pm
+-------------
+We've implemented a new anti-vulch, anti-twink experience system -- he who does the most
+damage to an NPC gets the exp upon its death (or the group he's in).  Let us know how it
+works.  Also, expect some larger downloads short term -- the world of Norrath expandeth.
+
+8/11/98 5:15pm
+--------------
+South Ro and Oasis are online now -- please do not try to go further south than South Ro,
+in that that zone isn't up yet.  The world will continue to expand in that general direction
+(south of Freeport), and soon Trolls and Ogres will have their hometowns.
+
+8/22/98 8:00pm
+--------------
+Grobb, Oggok, Rathe Mountains, and Lake Rathetear are online now.  We will be starting
+Trolls and Ogres in their respective hometowns shortly, as well as relocating existing
+Trolls and Ogres there (ie. Neriak will no longer be your hometown).  Also, we've
+added a new warrior skill called Taunt -- this skill, when successful, will re-focus
+target NPC to attack you (ie. he will switch from his current target to you).  This is
+useful, for example, when an NPC targets a spellcaster or healer in your party, and
+you'd like him instead to beat on you.
+
+8/31/98 12:41pm
+---------------
+We've added a new command, /feedback.  Please use /feedback to leave us feedback and comments
+and only use /bug for bugs.  They are written to two separate files now, which will make it
+easier for us to get the information to the appropriate people.  Thanks.
+
+9/1/98 5:03pm (IMPORTANT - PLEASE READ)
+----------------------------------------
+We are starting to build up the Game Master (GM) infrastructure for EverQuest.  If you require assistance in-game, use the /petition <msg> command -- all GMs online will receive your message
+and you will be helped as soon as possible -- using the /tell command to solicit help from a GM is no longer legal.  Note that there are serveral kinds of GMs you might encounter in-game, but
+there are only two kinds responsible for helping testers -- GUIDES, and GM-Admin GMs.  Other GMs (coders, areas, etc.) are development team members and are not there to help you (sorry -- but
+they need to finish the game).  GUIDES are external (non-Sony) GMs who are there to help you and answer questions, but their power is limited (meaning they will often refer you to a GM-Admin).
+Our plan is to have GM-Admins in-game most of the time, all week, but it may take some time for this coverage to become complete.
+
+SOME NEW POLICIES:
+-- NO reimbursals of lost items, money, or experience will be made (sorry, but this is a BETA).
+-- Using the /tell command to solicit help from a GM is no longer legal -- use the /petition command.
+-- Using 'safe' areas (ie. areas where NPCs can't or won't go, even though it makes sense they could) is illegal.  Fighting NPCs, or using those areas to rest and heal, is not allowed.  An example would
+be areas near zone transition sections.  These problem areas are being fixed as quickly as possible, but in the meantime, testers caught abusing these areas won't be testers for long.
+
+9/4/98 6:35pm
+-------------
+There will be a player wipe (pwipe) Tuesday morning at approximately 10am pacific.  This is in preperation for Phase 2 of the EverQuest beta test, which begins early next week.  
+You may have ONE character's level re-imbursed, and you will be given some gold based upon that character's level.  
+To register one of your characters, use the /feedback command, and begin the message with REGISTER.  Make sure you
+are logged on as the character you want to save (we are recording your name, race, class, and level).  Once the
+pwipe is complete, we will post a message here explaining how to get re-imbursed.  Note that artificially 'buffed'
+characters are not eligible for restoration.  If possible, we reccomend using the /feedback command late Monday or so such that if you level over the weekend, it will be recorded.
+
+9/8/98 1:00pm
+-------------
+As you may well know, the player wipe (pwipe) has been performed.  There will be no reimbursment of items, weapons,
+or armor.  Character level and gold will be reimbursed to those who registered via the "/feedback" command, as stated in the
+previous announcement.  For those of you that did register your character, use the "/petition" command to notify a GM and you
+will be reimbursed.
+
+9/15/98 1:26am
+--------------
+Good morning citizens of Norrath!  The world will be expanding over the next few days.  Beginning this afternoon, we will be adding two new zones per day, everyday.  
+It would be wise for modem users to connect and patch at least once a day.  The majority of the zones which make up Faydwer will be added so elves, dwarves, and gnomes may begin in their
+respective homelands.  Shortly after this batch of zones are up, we will begin moving characters to the new continent.  We apologize for the large amount of data that will be required to download,
+but once complete the downloads will of course be kept to a minimum.
+
+9/28/98 4:00pm
+--------------
+We have recently added a bug discussion and entry forum, which can be found at "www.sonyinteractive.com/eqbugs/".  This forum can be accessed by using your EverQuest login ID and password.
+Team members will frequent this board often to post responses and updates regarding posted bugs as well as asking for assistance with specific bug and balance issues.  Also, in-depth game
+information, such as the "faction" explanation which was posted this weekend, will be available through the site.
+
+9/30/98 5:17pm
+--------------
+The "Bind Wounds"/Bandage skill will now only work on people who have fifty hitpoints or less remaining.
+The "Meditate" skill has been improved in regards to Mana regeneration times.
+
+10/1/98 2:00pm
+--------------
+A new command has been added:
+/Random <#> <#>  - This will give you a random number from # to # (i.g. "/Random 1 10" would give you a random number from 1 to 10 inclusive). If you only specify one number (i.e. "/Random 5") it assumes 0 to the number you supplied.
+The "/Who" command now has an additional option: "corpse" (i.e. "/Who corpse") allows you to see if any of your corpses are in your current zone.
+
+10/6/98 2:21pm
+--------------
+Anyone playing the game with a Diamond Viper V330 videocard should go to Diamond's webpage (www.diamondmm.com) and get the latest drivers.  Their newest drivers fix some crash bugs (like walking from one zone to another, and some random crashes) and should make EverQuest much more stable.
+With perhaps a few exceptions, it is generally a good idea to update to the latest release drivers for any videocard, or any other piece of hardware for that matter.
+
+10/17/98 7:23pm
+---------------
+Bards should now be able to sing their songs and fight at the same time (Bards are the only ones though).
+

--- a/patches-phase3beta-revisions.txt
+++ b/patches-phase3beta-revisions.txt
@@ -1,0 +1,104 @@
+07/7/98 4:18PM
+---------------
+There is now a text file called "revision.txt", where you will find a more extensive list of changes that were made.  There has also been a large addition/update to the manual (Everquest_Manual.txt), check it out.
+
+07/13/98 5:00pm
+----------------
+Be careful! NPCs now use their skills properly if they have them, so you might just get
+kicked or bashed.  Only humanoid type NPCs (like Gnolls) use skills.
+
+Changes:
+  Bash no longer guarantees that something will be stunned, which means it is more
+            difficult to keep an NPC bashed, but the NPCs will also have a harder time keeping
+            YOU bashed.
+
+  The "N" key (Target nearest NPC) will no longer target NPC corpses, only living NPCs.
+
+Two new commands were added:
+  /split - Split a specified amount of money amongst your group members.
+              Format: /split <plat> <gold> <silver> <copper>
+             Example: /split 0 0 0 15 would split 15 copper amongst your group members.
+              which means split 0 plat, 0 gold, 0 silver, 15 copper. /split 1 5
+               would split 1 platinum, 5 gold, so trailing zeros are  not necessary,
+              but the preceeding zeros ARE necessary.
+  /autosplit - Toggle automatic splitting of money looted with your group ON and OFF.
+
+A few bugs were fixed:
+   Arrows will no longer become "supercharged" in damage over time.
+  "Shield of Brambles" type spells will no longer damage the thing they are protecting.
+  Spells like "Disease Cloud" no longer have unlimited range.
+  
+7/7/98 5:02PM
+-------------
+New keyboard shortcuts: (These work when the chatbar is NOT up, just like "Z" now)
+
+"T" = Target nearest entity (Player or NPC),
+"N" = Target nearest NPC,
+"U" = Use center of view, which is just like a double-left click at the center
+             of the 3dview.  Which has many uses, such as opening a door, starting a
+             transaction with a merchant or guildmaster, target and consider someone,
+             begin looting a corpse, and more...
+"1" - "6"                = Activate the six "Hotboxes" currently showing on your screen.
+"+" and "-" = Cycle up and down through the banks of "Hotboxes".
+CTRL + PGUP = Scroll the text window up one page.
+CTRL + PGDOWN = Scroll the text window down one page.
+
+Beware! You will now move slower when you have less than 1/3 of your total hitpoints
+left.  This change does not affect any characters below level 4 in order to give
+newbies a short grace period, but all characters over level 3 had best be wary.
+
+There has been a fair amount of tweaking done, especially to the Monk class, so be
+more careful than usual until you "feel out" the changes.
+
+Throwing weapons and bows should now be viable.  Arrows and thrown weapons will fall
+to the ground after they hit something/someone, and can be picked up.  Give them a try.
+
+A few bugs were fixed:
+  - Languages should now completely work, give them a try.
+  - Your corpses should still be where you left them, even after a crash now.
+  - The "Who" button was fixed, and should now show a list of who is in your zone.
+  - Many more small interfaces problems...
+  
+7/15/98 7:32pm
+--------------
+Added Halas (the Barbarian hometown) to the patch server -- new barbarians will start there within the next few days.
+
+7/16/98 6:16pm
+--------------
+Barbarians now start in Halas.  Neriak, Freeport, and Rivervale will be online soon.
+
+7/17/98 11:55am
+----------------
+There will be a player wipe tonight.  IF and only if you talk to Generyk the GM before the wipe, you will be reimbursed your level on ONE character, and you will be given 7 gold per level.  No other GM will help you in this matter, and this is not something negotiable.  PWipes are an unfortunate aspect of beta testing -- we do them as infrequently as possible -- please hang tough and bear with it.
+
+7/17/98 6:17pm
+-------------
+The player wipe is done.  IMPORTANT: When you create your new characters, either choose a fantasy sounding name or use the name generator -- if you are caught with a non-compliant name, you will be warned.  Lastly, one or more noticible changes we've made is that spell scrolls now cost more money, depending on their level.  Other more minor, albeit numerous, changes were made to weapon and spell damages.
+
+7/20/98 5:46pm
+--------------
+That nasty and evil download was brought to you by the dark elves (ie. Neriak is up!).  Within the next day or two dark elves, ogres, and trolls will start in Neriak, while dwarves, gnomes, and halflings will start in Rivervale (until all home towns are online).  Also, considering an NPC is now more accurate and clear -- descriptions are better and the text is now color coded such that green means no exp. for the kill, blue means the NPC is lower lvl than you, black the same level, yellow higher, and red...stay away from red :)
+
+7/22/98 1:37pm
+--------------
+Should be more faces in the game, as well as some updated characters -- that's the big file you just received.  Also, Glide support is now in the game.  Glide is an API from 3dfx that works with their Voodoo cards -- note that EQ uses Glide 3.0, which currently only works on Voodoo 2s, but should soon work on Voodoo 1s.  800x600 support is in with the Voodoo 2s under Glide.  Make sure you have the most recent drivers from www.3dfx.com.
+
+7/30/98 5:30pm
+---------------
+We've hopefully fixed a nasty bug that was causing a spell casting to crash -- let us know if you are still getting any crash bugs.  Also, the newbie zones adjacent to the newer cities are being turned -- both more and a better range of NPCs should be appearing in them over the next week.  Also, slowly but surely, more and more NPCs will talk and even give quests -- a good way to begin a conversation is to target the NPC, and /say hello <npc's name>.
+
+8/3/98 5:34pm
+-------------
+There is a bug we've discovered in the latest reference drivers for Voodoo 1 based cards in D3D mode.  If you are having severe video problems in-game, we reccomend you revert to either an earlier reference driver or use the card's manufacturer's driver (for example, the Diamond Monster drivers v.1.10 work fine).
+
+8/3/98 9:00pm
+-------------
+East Freeport is finally up -- the entire city of Freeport is online now.  Also, several of the crash bugs we've had should be fixed now -- let us know if you encounter any more and please attempt to make note of the circumstances and events immediately prior to the crash.  Lastly, an assist command has been added -- target a player, type /assist, and you should then target whoever he is currently fighting at that moment.
+
+8/4/98 4:44pm
+------------
+Note the changes to the previous entry regarding the assist command.
+
+8/4/98 5:55pm
+------------
+Hopefully the Voodoo 1 D3D bug has a workaround -- please let us know if you experience any additional problems.  Also, you can start a character (human, half-elf, wood elf, high elf) in Freeport now (in addition to Qeynos) -- give it a try.

--- a/patches-phase4beta.txt
+++ b/patches-phase4beta.txt
@@ -1,0 +1,104 @@
+The following Beta 4 patch messages were sourced from:
+* https://web.archive.org/web/20001006113622/http://www3.jcss.net/~rpg/eqi/news/99-3-1.htm
+* https://web.archive.org/web/20010312012332/http://www3.jcss.net/~rpg/eqi/news/99-3-15.htm
+
+Friday, March 5, 1999
+------------
+Patch server message:
+
+With March 16 approaching, the EQ team is fixing various bugs and improving the game with fire cars throughout the night. A new "/corpse" command has been introduced to recover your items from corpses. You can use this command with a radius of 50' for your corpse to attract the corpse. However, the /corpse command cannot recover corpses from lava. In addition, we added a friends list and random number commands. Both of EverQuest_Manual.txt described in the file. The bugs that have been fixed are as follows:
+
+    * Minor Illusion magic now works normally. It becomes visible as the object that the person changed his appearance.
+    * Various modifications to boat travel.
+    * You will need food and drinks to recover From Stamina.
+    
+Saturday, March 6, 1999
+--------------
+Patch server message:
+
+Several Test server bugs have been fixed in this update:
+
+    * The bow pulls a line on the interface and sometimes crashes occur.
+    * The line goes down when using the "/corpse" command.
+    * Mesmerize's effect on Beard and Enchanter has been fixed and works as planned.
+    * When you go out of the character or server selection screen and press the "Play EverQuest" button, an illegal process occurs.
+    * If the HomePoint is down when the character dies, the user crashes. This time, you can now return to the character selection screen instead of crashing until HomePoint is back online.
+    * The equipped flying gear cannot be seen on the character's appearance until you set it up.
+    * Texts could spam a user's chat bar when giving instructions to a pet.
+    * If you jump into the water with Torch and remove it and have it again, the torch will not disappear even underwater.
+    * When using the magic of "Eye of Zomm", the eyes (*summoned by magic) turn only in a certain direction.
+    * If you receive a message that the Fishing pole is broken while fishing, it will not actually be damaged.
+    * If you buy more than one of the same magic scrolls, inventory will show only one scroll.
+    * When you give other players the right to secure their inventory from their corpses in the /content, they will be asked to use the "You are given permission to loop corp." I get a message.
+    * When I get on the boat, I can't hear the sound effects of the sea.
+    * Display mode settings are not saved.
+    * Text overlaps when the Spell book and options menu are open.
+    * Hotkeys cannot be used during Meditation.
+    * When a player has an option menu open in Anonymous (anonymous mode), the character is not actually anonymous.
+    * When using the Autosplit feature, when a party member recovers his or her items from his or her corpse, the money in the corpse is distributed.
+    * Various grammatic changes to the description of the race and class in the character selection screen.
+    * When you place an item that is "stacked" on the trade screen, the number of items is not displayed correctly on the screen on the receiving side.
+    
+Monday, March 8, 1999
+-------------
+Patch server message:
+
+The following fixes are in the latest patch:
+
+    1. Fixed an issue where a Dwarf man would look unusually large when holding a weapon in his left hand.
+    2. Gamma settings have been fixed and tested, and the in-game options menu can now be set again.
+    3. Fixed an issue where keys (Combat, Social, etc.) on the right side of the screen would sometimes crash.
+    4. Fixed an issue where accessing the options menu and dragging the mouse icon over it would appear in the graphic.
+    5. If you leave it in inventory, certain items that appear on your corpse will now disappear from Inventory.
+    6. Fixed an issue where the fruit would look the same as a Muffin.
+    7. Fixed an issue where an item would disappear when placed on the ground.
+    8. Various "safe zones" are gone.
+    
+Tuesday, March 9, 1999
+--------------
+
+Patch server message:
+
+Ladies and gentlemen of Norrath, it's coming to an end!
+
+EverQust Phase 4 beta testing ends Friday, Friday 12th at midnight.
+
+Last night's patch lag and line disconnection are likely to have been mitigated in this patch. Here are some fixes:
+
+    1. Players can now change the direction of the empty while root is no longer working.
+    2. Fixed an issue where the wizard could not see the magic on the target in a message.
+    3. Fixed an issue where eye of zomm magic would disappear when entering the water.
+    4. Fixed an issue where players who received the message would see extra characters when executing the /shout, /tell, /group command and typing 16 characters in a row (without spaces).
+    5. Fixed an issue where the food raised could not be stacked.
+    6. Fixed an issue where "Opal Sycthe" could not be caught from NPC corpses.
+    7. Fixed a dark issue with Diamond Viper V550 when the screen brightness changed to gamma settings.
+    8. Fixed an issue where stunned characters could be in that state forever.
+    9. Fixed an issue where players could not move when minor illustrator magic was hanging.
+    
+Thursday, March 11 1999
+------------------
+
+Fixed some major bugs related to sound and crashes. In addition, changes have been made to the decay system of corpses, which are described below;
+
+The next patch will be introduced immediately. It includes changes to the decay of corpses, and all corpses on the Test server are erased. This makes it much longer for corpses to rot if the player's account is not logged into North. If you don't mind losing a body due to this change, don't log out or let your character head to a place where you're at risk of dying. When you get a new patch, sacrifice your newly created and current characters to test this change.
+
+The fix is as follows;
+
+Level 1 corpses remain for an hour if they are not logged in with that account.
+
+Level 2-5 corpses remain for only 8 hours if they are not logged in with that account.
+
+Level 6 or higher corpses remain for only 7 days if they are not logged in with that account.
+
+The numbers above are related to the corpse and the items that remain, and do not include the item as needed. While the corpse's account is logged in, the decay time is as before.
+
+Other bug fixes:
+
+    * Fixed a bug where the connection would be lost after death and return to the character selection screen.
+    * Fixed a crash when switching zones.
+    * Fixed a lot of issues related to quests and NPC words.
+    * Fixed an issue where removing items from the trade window would not disappear.
+    * Fixed an issue where new characters could not get guild tunics for a class.
+    * Fixed an issue where creatures jumping over water would swim on the ground.
+    * Fixed an issue where characters would fly somewhere if they lost their mind when There was no food or water in Inventory.
+    


### PR DESCRIPTION
Adds changelog, "revisions.txt" and "eqnews.txt" from the Everquest Phase 3 Beta CD - thanks to the EQClassic/Project Lantern team for sharing the content from those files.  Adds known Phase 4 Beta changelog from https://web.archive.org/web/20010312012332/http://www3.jcss.net/~rpg/eqi/news/99-3-15.htm and https://web.archive.org/web/20001006113622/http://www3.jcss.net/~rpg/eqi/news/99-3-1.htm.